### PR TITLE
Add optional root directory for concatenated files

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,16 @@ function onDomReady(){ ... }
 $(onDomReady);
 ```
 
-These will reside under the asset build directory in a sub-directory named `concat`.
+### Specifying the output location
+
+By default the concatenated files will reside under the asset build directory in a sub-directory named `concat`.
+This can be changed by specifying the rhe root property withing you `build.sbt` file.
+
+This will build files directly into the asset build directory:
+
+ ```scala
+ Concat.root := ""
+ ```
 
 License
 =======

--- a/src/sbt-test/sbt-concat/custom/built.sbt
+++ b/src/sbt-test/sbt-concat/custom/built.sbt
@@ -1,0 +1,41 @@
+import com.typesafe.sbt.web.Import._
+import com.typesafe.sbt.web.Import.WebKeys._
+organization := "net.ground5hark.sbt"
+
+name := "sbt-concat-test"
+
+version := "0.1.2"
+
+scalaVersion := "2.10.4"
+
+lazy val root = (project in file(".")).enablePlugins(SbtWeb)
+
+Concat.root := ""
+
+Concat.groups := Seq(
+  "css/style-group.css" -> Seq("style1.css", "style2.css"),
+  "js/script-group.js" -> Seq("file1.js", "file2.js")
+)
+
+pipelineStages := Seq(concat)
+
+val verifyConcatContents = taskKey[Unit]("Verify contents of concatenation groups")
+
+verifyConcatContents := {
+  val pub = (public in Assets).value
+  val concatCss = (pub / "" ** "*style-group.css").get
+  val concatJs = (pub / "" ** "*script-group.js").get
+  def assertEqual(f: File, contains: Seq[String]): Unit = {
+    val contents = IO.read(f)
+    contains.foreach { s =>
+      if (!contents.contains(s))
+        sys.error(s"${f.getName}: Expected `$s` to be in `$contents`")
+    }
+  }
+  val containsCss = Seq("background-color: #000;", "/** style2.css **/",
+                        "/** style1.css **/", "font-face: Arial, sans-serif;")
+  assertEqual(concatCss.head, containsCss)
+  val containsJs = Seq("file1Callback = function() {", "/** file2.js **/",
+                       "console.log('file2 - callback called');")
+  assertEqual(concatJs.head, containsJs)
+}

--- a/src/sbt-test/sbt-concat/custom/project/build.properties
+++ b/src/sbt-test/sbt-concat/custom/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.5

--- a/src/sbt-test/sbt-concat/custom/project/plugins.sbt
+++ b/src/sbt-test/sbt-concat/custom/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("net.ground5hark.sbt" %% "sbt-concat" % sys.props("project.version"))

--- a/src/sbt-test/sbt-concat/custom/src/main/assets/css/style1.css
+++ b/src/sbt-test/sbt-concat/custom/src/main/assets/css/style1.css
@@ -1,0 +1,4 @@
+body {
+    color: #fff;
+    background-color: #000;
+}

--- a/src/sbt-test/sbt-concat/custom/src/main/assets/css/style2.css
+++ b/src/sbt-test/sbt-concat/custom/src/main/assets/css/style2.css
@@ -1,0 +1,4 @@
+footer {
+    font-face: Arial, sans-serif;
+    font-size: 16px;
+}

--- a/src/sbt-test/sbt-concat/custom/src/main/assets/js/file1.js
+++ b/src/sbt-test/sbt-concat/custom/src/main/assets/js/file1.js
@@ -1,0 +1,3 @@
+var file1Callback = function() {
+    console.log('file1 - callback called');
+};

--- a/src/sbt-test/sbt-concat/custom/src/main/assets/js/file2.js
+++ b/src/sbt-test/sbt-concat/custom/src/main/assets/js/file2.js
@@ -1,0 +1,3 @@
+function file2Callback() {
+    console.log('file2 - callback called');
+};

--- a/src/sbt-test/sbt-concat/custom/src/main/assets/js/file3.js
+++ b/src/sbt-test/sbt-concat/custom/src/main/assets/js/file3.js
@@ -1,0 +1,3 @@
+(function(){
+  console.log('hello');
+}());

--- a/src/sbt-test/sbt-concat/custom/test
+++ b/src/sbt-test/sbt-concat/custom/test
@@ -1,0 +1,10 @@
+> webStage
+$ exists target/web/stage/js/script-group.js
+$ exists target/web/stage/css/style-group.css
+$ exists target/web/public/main/js/script-group.js
+$ exists target/web/public/main/css/style-group.css
+# Stuff not specified in the concat group should still be there
+$ exists target/web/stage/js/file3.js
+
+# Verify contents joined correctly
+> verifyConcatContents


### PR DESCRIPTION
This adds a new configuration setting to specify the root directory for concatenated files. I have left the default to be "concat" but the user is free to change the directory name or even have the files built directly into the root public directory.
